### PR TITLE
Fix ignored github action failures

### DIFF
--- a/renode_run/__main__.py
+++ b/renode_run/__main__.py
@@ -312,7 +312,9 @@ def test_command(args):
     env['PATH'] = f'{python_bin}:' + (env['PATH'] or '')
 
     renode_args = list(arg for arg in getattr(args, 'renode_args', []) if arg != '--')
-    subprocess.run([renode_test] + renode_args, env=env)
+    result = subprocess.run([renode_test] + renode_args, env=env)
+    if result.returncode != 0:
+        raise Exception("There has been an error when running the tests. Check the output above.")
 
 
 def main():


### PR DESCRIPTION
GitHub is reporting that my build has failed when there are robotframework errors. I believe this is because subprocess.run won't report a non-zero exit code and this causes the tests to pass.

So when it gets called here it returns an exit code of 0:
https://github.com/antmicro/renode-test-action/blob/9382fe730c6e399eb4af2616e16e27d790a4f793/src/run_renode_test.sh#L34

Example "passed" build: https://github.com/Solar-Gators/Sunrider-TelemetryFirmware-2022/actions/runs/3304505510/jobs/5453975572